### PR TITLE
追加読み込み時に画面がチラつくバグを修正

### DIFF
--- a/search-github-user-app.xcodeproj/project.pbxproj
+++ b/search-github-user-app.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		CA7ADEDE2A189DC400971CD7 /* WebViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7ADEDD2A189DC400971CD7 /* WebViewPresenter.swift */; };
 		CA7ADEE12A18A16200971CD7 /* WebViewOutputCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7ADEE02A18A16200971CD7 /* WebViewOutputCollection.swift */; };
 		CA7ADEE32A18A16F00971CD7 /* WebViewInputCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7ADEE22A18A16F00971CD7 /* WebViewInputCollection.swift */; };
+		CAE313652A1B990200379B85 /* UserSearchResultWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE313642A1B990200379B85 /* UserSearchResultWrapper.swift */; };
+		CAE313672A1B9DF200379B85 /* RepositoryWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE313662A1B9DF200379B85 /* RepositoryWrapper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -83,6 +85,8 @@
 		CA7ADEDD2A189DC400971CD7 /* WebViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewPresenter.swift; sourceTree = "<group>"; };
 		CA7ADEE02A18A16200971CD7 /* WebViewOutputCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewOutputCollection.swift; sourceTree = "<group>"; };
 		CA7ADEE22A18A16F00971CD7 /* WebViewInputCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewInputCollection.swift; sourceTree = "<group>"; };
+		CAE313642A1B990200379B85 /* UserSearchResultWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSearchResultWrapper.swift; sourceTree = "<group>"; };
+		CAE313662A1B9DF200379B85 /* RepositoryWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryWrapper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -157,10 +161,12 @@
 			isa = PBXGroup;
 			children = (
 				CA4665432A160371002683E3 /* UserSearchResult.swift */,
+				CAE313662A1B9DF200379B85 /* RepositoryWrapper.swift */,
 				CA7ADE9F2A16803C00971CD7 /* RepositorySearchResult.swift */,
 				CA4665452A16038A002683E3 /* UserWrapper.swift */,
 				CA7ADE992A164CD300971CD7 /* User.swift */,
 				CA7ADE9B2A16790D00971CD7 /* Repository.swift */,
+				CAE313642A1B990200379B85 /* UserSearchResultWrapper.swift */,
 			);
 			path = Codable;
 			sourceTree = "<group>";
@@ -406,6 +412,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CA7ADECF2A17F6D500971CD7 /* RootPresenter.swift in Sources */,
+				CAE313652A1B990200379B85 /* UserSearchResultWrapper.swift in Sources */,
 				CA4665412A15FF57002683E3 /* Env.swift in Sources */,
 				CA46653E2A15FC6D002683E3 /* GitHubAPIClient.swift in Sources */,
 				CA7ADEDA2A18093300971CD7 /* UserDetailInputCollection.swift in Sources */,
@@ -429,6 +436,7 @@
 				CA7ADEDE2A189DC400971CD7 /* WebViewPresenter.swift in Sources */,
 				CA7ADEDC2A18097D00971CD7 /* UserDetailOutputCollection.swift in Sources */,
 				CA7ADED52A17FB7A00971CD7 /* RootInputCollection.swift in Sources */,
+				CAE313672A1B9DF200379B85 /* RepositoryWrapper.swift in Sources */,
 				CA7ADEA22A179AA700971CD7 /* WebViewController.swift in Sources */,
 				CA4665462A16038B002683E3 /* UserWrapper.swift in Sources */,
 				CA7ADEE32A18A16F00971CD7 /* WebViewInputCollection.swift in Sources */,

--- a/search-github-user-app/Codable/RepositoryWrapper.swift
+++ b/search-github-user-app/Codable/RepositoryWrapper.swift
@@ -1,0 +1,13 @@
+//
+//  RepositoryWrapper.swift
+//  search-github-user-app
+//
+//  Created by ToshiPro01 on 2023/05/22.
+//
+
+import Foundation
+
+struct RepositoryWrapper {
+    let repositories: [Repository]
+    let lastPage: Int?
+}

--- a/search-github-user-app/Codable/UserSearchResultWrapper.swift
+++ b/search-github-user-app/Codable/UserSearchResultWrapper.swift
@@ -1,0 +1,13 @@
+//
+//  UserSearchResultWrapper.swift
+//  search-github-user-app
+//
+//  Created by ToshiPro01 on 2023/05/22.
+//
+
+import Foundation
+
+struct UserSearchResultWrapper {
+    let userSearchResult: UserSearchResult?
+    let lastPage: Int?
+}

--- a/search-github-user-app/Presenter/RootPresenter.swift
+++ b/search-github-user-app/Presenter/RootPresenter.swift
@@ -18,6 +18,7 @@ final class RootPresenter {
     private(set) var users: [UserWrapper] = []
     private var loadState: LoadState = .none
     private var page = 1
+    private var lastPage = 1
     private var searchedWord = ""
 
     init(view: RootOutputCollection) {
@@ -40,13 +41,16 @@ extension RootPresenter: RootInputCollection {
             do {
                 let fetchUsers = try await GitHubAPIClient.shared.getUsers(keyword: searchedWord, page: page)
 
-                users += fetchUsers?.items ?? []
+                if let lastPage = fetchUsers.lastPage {
+                    self.lastPage = lastPage
+                }
+                users += fetchUsers.userSearchResult?.items ?? []
                 loadState = .standby
                 view.tableReload()
                 view.stopAnimatingIndicator()
 
                 if page == 1 {
-                    view.setTotalCount(fetchUsers?.totalCount ?? 0)
+                    view.setTotalCount(fetchUsers.userSearchResult?.totalCount ?? 0)
                 }
             } catch let error as APIError {
                 print("error: \(error.description)")
@@ -61,10 +65,12 @@ extension RootPresenter: RootInputCollection {
     @MainActor
     func approachTableViewBottom() {
         guard loadState == .standby else { return }
+        guard lastPage != page else { return }
 
+        page += 1
         view.startAnimatingIndicator()
         loadState = .loading
-        page += 1
+
         getUsers()
     }
 
@@ -81,6 +87,7 @@ extension RootPresenter: RootInputCollection {
         view.startAnimatingIndicator()
         page = 1
         users = []
+        lastPage = 1
         loadState = .loading
         getUsers()
     }

--- a/search-github-user-app/Screen/UserDetail/UserDetailViewController.swift
+++ b/search-github-user-app/Screen/UserDetail/UserDetailViewController.swift
@@ -116,7 +116,7 @@ extension UserDetailViewController {
         // 現在の位置からスクロールの最下部までの距離
         let distance = maxContentOffsetY - currentContentOffsetY
         // 最下部から一定距離に近づいたら追加読み込みする
-        if distance < 50 {
+        if distance < 10 {
             presenter.approachTableViewBottom()
         }
     }


### PR DESCRIPTION
#25 ラストページは追加読み込みしないよう修正

## 原因
最終ページの判定をしていなかったため、最終ページまで読み込んでいても再読み込みをしていて画面がチラついて見えていた